### PR TITLE
Simplify Maven Central publishing setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          ./gradlew --no-daemon \
-            :telegram-boot-core:publish \
-            :telegram-boot-autoconfigure:publish \
-            :telegram-boot-spring-boot-starter:publish
+        run: ./gradlew --no-daemon publishToMavenCentral
 
       - name: Summarize published version
         if: ${{ success() }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.kotlin.dsl.configure
 
 plugins {
     java
@@ -42,6 +44,23 @@ subprojects {
         testLogging {
             events = setOf(TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED)
             exceptionFormat = TestExceptionFormat.FULL
+        }
+    }
+
+    pluginManager.withPlugin("maven-publish") {
+        configure<PublishingExtension> {
+            repositories {
+                mavenCentral {
+                    credentials {
+                        username = providers.gradleProperty("sonatypeUsername")
+                            .orElse(providers.environmentVariable("SONATYPE_USERNAME"))
+                            .orNull
+                        password = providers.gradleProperty("sonatypePassword")
+                            .orElse(providers.environmentVariable("SONATYPE_PASSWORD"))
+                            .orNull
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- rely on Gradle's built-in Maven Central repository support for modules that apply the maven-publish plugin
- invoke the aggregate publishToMavenCentral task in the publish workflow instead of calling each module task individually

## Testing
- ./gradlew --no-daemon build *(fails: Cannot find a Java installation matching languageVersion=25 without configured download repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dafb9c748328aa55ed1d88e7ea0e