### PR TITLE
Add aggregate Maven Central publish task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          ./gradlew --no-daemon \
-            :telegram-boot-core:publish \
-            :telegram-boot-autoconfigure:publish \
-            :telegram-boot-spring-boot-starter:publish
+        run: ./gradlew --no-daemon publishToMavenCentral
 
       - name: Summarize published version
         if: ${{ success() }}


### PR DESCRIPTION
## Summary
- add a root-level publishToMavenCentral task that depends on each module's Maven Central publication task
- hook maven-publish modules into the aggregate task

## Testing
- ./gradlew --no-daemon build *(fails: Cannot find a Java installation matching languageVersion=25 without configured download repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dafb9c748328aa55ed1d88e7ea0e