### PR TITLE
Reference Spring Boot platform in module metadata

### DIFF
--- a/telegram-boot-autoconfigure/build.gradle.kts
+++ b/telegram-boot-autoconfigure/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 }
 
 dependencies {
+    val springBootVersion: String by rootProject.extra
+
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     implementation(project(":telegram-boot-core"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
 
@@ -15,6 +18,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
+    testImplementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/telegram-boot-core/build.gradle.kts
+++ b/telegram-boot-core/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 }
 
 dependencies {
+    val springBootVersion: String by rootProject.extra
+
+    api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     api("org.springframework.boot:spring-boot")
 
     implementation("org.slf4j:slf4j-api")
@@ -16,6 +19,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
+    testImplementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/telegram-boot-spring-boot-starter/build.gradle.kts
+++ b/telegram-boot-spring-boot-starter/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
 }
 
 dependencies {
+    val springBootVersion: String by rootProject.extra
+
+    api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     api(project(":telegram-boot-core"))
     implementation(project(":telegram-boot-autoconfigure"))
 }


### PR DESCRIPTION
## Summary
- import the Spring Boot dependency BOM as a platform in the core, autoconfigure, and starter modules
- align test configurations with the Spring Boot platform to provide versioned metadata during publication

## Testing
- ./gradlew build *(fails: Java toolchain 25 is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d722cd03c4832896ddbd7c4d69babb