### PR TITLE
Bump Spring Boot to 3.5.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
 }
 
-val springBootVersion by extra("3.5.0-SNAPSHOT")
+val springBootVersion by extra("3.5.6")
 
 allprojects {
     group = "io.github.pm665"
@@ -15,8 +15,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven("https://repo.spring.io/milestone")
-        maven("https://repo.spring.io/snapshot")
     }
 }
 


### PR DESCRIPTION
## Summary
- update the shared Spring Boot BOM version to the 3.5.6 release

## Testing
- `./gradlew test --no-daemon` *(fails: required Java toolchain (25) is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d737523c2c8328940b87932f8b6c7d