### PR TITLE
Adjust bot command provider method names

### DIFF
--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/BotCommand.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/BotCommand.kt
@@ -1,0 +1,7 @@
+package io.github.pm665.telegram.boot.command
+
+data class BotCommand(
+    val name: String,
+    val action: String,
+    val enabled: Boolean,
+)

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/BotCommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/BotCommandProvider.kt
@@ -1,0 +1,11 @@
+package io.github.pm665.telegram.boot.command
+
+interface BotCommandProvider {
+    fun getCommands(): Collection<BotCommand>
+
+    fun getCommand(name: String): BotCommand?
+
+    fun addCommand(command: BotCommand)
+
+    fun removeCommand(name: String)
+}

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/InMemoryBotCommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegram/boot/command/InMemoryBotCommandProvider.kt
@@ -1,0 +1,24 @@
+package io.github.pm665.telegram.boot.command
+
+import java.util.concurrent.ConcurrentHashMap
+
+class InMemoryBotCommandProvider(
+    initialCommands: Collection<BotCommand> = emptyList(),
+) : BotCommandProvider {
+
+    private val commands = ConcurrentHashMap<String, BotCommand>().apply {
+        initialCommands.forEach { put(it.name, it) }
+    }
+
+    override fun getCommands(): Collection<BotCommand> = commands.values.toList()
+
+    override fun getCommand(name: String): BotCommand? = commands[name]
+
+    override fun addCommand(command: BotCommand) {
+        commands[command.name] = command
+    }
+
+    override fun removeCommand(name: String) {
+        commands.remove(name)
+    }
+}


### PR DESCRIPTION
## Summary
- rename the `BotCommandProvider` CRUD methods to the `get*/add*/remove*` pattern requested for parity with the bot provider
- update the in-memory provider implementation to conform to the revised interface semantics

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9c66fd5a48328a41562fc0c69c03c