### PR TITLE
Add message model and provider support

### DIFF
--- a/telegram-boot-autoconfigure/src/main/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfiguration.kt
+++ b/telegram-boot-autoconfigure/src/main/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfiguration.kt
@@ -5,14 +5,16 @@ import io.github.pm665.telegramboot.adapters.InMemoryBotProvider
 import io.github.pm665.telegramboot.adapters.InMemoryBotUserProvider
 import io.github.pm665.telegramboot.adapters.InMemoryCommandProvider
 import io.github.pm665.telegramboot.adapters.InMemoryMenuProvider
+import io.github.pm665.telegramboot.adapters.InMemoryMessageProvider
 import io.github.pm665.telegramboot.adapters.InMemoryUserRoleProvider
 import io.github.pm665.telegramboot.domain.configuration.TelegramBootProperties
 import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
-import io.github.pm665.telegramboot.ports.BotProvider
 import io.github.pm665.telegramboot.ports.BotChatProvider
+import io.github.pm665.telegramboot.ports.BotProvider
 import io.github.pm665.telegramboot.ports.BotUserProvider
 import io.github.pm665.telegramboot.ports.CommandProvider
 import io.github.pm665.telegramboot.ports.MenuProvider
+import io.github.pm665.telegramboot.ports.MessageProvider
 import io.github.pm665.telegramboot.ports.UserRoleProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -48,6 +50,10 @@ class TelegramBootServiceAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun userRoleProvider(): UserRoleProvider = InMemoryUserRoleProvider()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun messageProvider(): MessageProvider = InMemoryMessageProvider()
 
     @Bean
     @ConditionalOnMissingBean

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMessageProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMessageProvider.kt
@@ -1,0 +1,24 @@
+package io.github.pm665.telegramboot.adapters
+
+import io.github.pm665.telegramboot.domain.telegram.Message
+import io.github.pm665.telegramboot.ports.MessageProvider
+import java.util.concurrent.ConcurrentHashMap
+
+class InMemoryMessageProvider : MessageProvider {
+    private val messages = ConcurrentHashMap<String, Message>()
+
+    override fun getMessages(): Collection<Message> = messages.values.toList()
+
+    override fun getByBotAndChat(
+        botUsername: String,
+        chatId: Long,
+    ): Collection<Message> = messages.values.filter { it.botUsername == botUsername && it.chatId == chatId }
+
+    override fun addMessage(message: Message) {
+        messages[message.id] = message
+    }
+
+    override fun removeMessage(messageId: String) {
+        messages.remove(messageId)
+    }
+}

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModels.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModels.kt
@@ -50,6 +50,14 @@ data class Menu(
     val order: Int = 0,
 )
 
+data class Message(
+    val id: String, // identifyiable by
+    val botUsername: String,
+    val chatId: Long,
+    val className: String,
+    val update: Any,
+)
+
 enum class CommandType {
     COMMAND,
     INFO_LINK,

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MessageProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MessageProvider.kt
@@ -1,0 +1,16 @@
+package io.github.pm665.telegramboot.ports
+
+import io.github.pm665.telegramboot.domain.telegram.Message
+
+interface MessageProvider {
+    fun getMessages(): Collection<Message>
+
+    fun getByBotAndChat(
+        botUsername: String,
+        chatId: Long,
+    ): Collection<Message>
+
+    fun addMessage(message: Message)
+
+    fun removeMessage(messageId: String)
+}


### PR DESCRIPTION
## Summary
- add a Message domain model to capture chat updates per bot
- introduce a message provider port with an in-memory implementation
- register the message provider in the auto-configuration to expose it by default

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db28d53b7c8328b32712b11c3db6bd