### PR TITLE
Add called command domain model and in-memory provider

### DIFF
--- a/telegram-boot-autoconfigure/src/main/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfiguration.kt
+++ b/telegram-boot-autoconfigure/src/main/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfiguration.kt
@@ -3,14 +3,16 @@ package io.github.pm665.telegramboot.bot.autoconfigure
 import io.github.pm665.telegramboot.adapters.InMemoryBotChatProvider
 import io.github.pm665.telegramboot.adapters.InMemoryBotProvider
 import io.github.pm665.telegramboot.adapters.InMemoryBotUserProvider
+import io.github.pm665.telegramboot.adapters.InMemoryCalledCommandProvider
 import io.github.pm665.telegramboot.adapters.InMemoryCommandProvider
 import io.github.pm665.telegramboot.adapters.InMemoryMenuProvider
 import io.github.pm665.telegramboot.adapters.InMemoryUserRoleProvider
 import io.github.pm665.telegramboot.domain.configuration.TelegramBootProperties
 import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
-import io.github.pm665.telegramboot.ports.BotProvider
 import io.github.pm665.telegramboot.ports.BotChatProvider
+import io.github.pm665.telegramboot.ports.BotProvider
 import io.github.pm665.telegramboot.ports.BotUserProvider
+import io.github.pm665.telegramboot.ports.CalledCommandProvider
 import io.github.pm665.telegramboot.ports.CommandProvider
 import io.github.pm665.telegramboot.ports.MenuProvider
 import io.github.pm665.telegramboot.ports.UserRoleProvider
@@ -40,6 +42,10 @@ class TelegramBootServiceAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun commandProvider(): CommandProvider = InMemoryCommandProvider()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun calledCommandProvider(): CalledCommandProvider = InMemoryCalledCommandProvider()
 
     @Bean
     @ConditionalOnMissingBean

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryCalledCommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryCalledCommandProvider.kt
@@ -1,0 +1,25 @@
+package io.github.pm665.telegramboot.adapters
+
+import io.github.pm665.telegramboot.domain.telegram.CalledCommand
+import io.github.pm665.telegramboot.ports.CalledCommandProvider
+import java.util.concurrent.CopyOnWriteArrayList
+
+class InMemoryCalledCommandProvider : CalledCommandProvider {
+    private val calledCommands = CopyOnWriteArrayList<CalledCommand>()
+
+    override fun getCalledCommands(): Collection<CalledCommand> = calledCommands.toList()
+
+    override fun getForBot(botUsername: String): Collection<CalledCommand> = calledCommands.filter { it.botUsername == botUsername }
+
+    override fun getForChat(
+        botUsername: String,
+        chatId: Long,
+    ): Collection<CalledCommand> =
+        calledCommands.filter {
+            it.botUsername == botUsername && it.chatId == chatId
+        }
+
+    override fun addCalledCommand(calledCommand: CalledCommand) {
+        calledCommands.add(calledCommand)
+    }
+}

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModels.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModels.kt
@@ -1,5 +1,7 @@
 package io.github.pm665.telegramboot.domain.telegram
 
+import java.time.LocalDateTime
+
 data class Bot(
     val botUsername: String, // identifyiable by
     val botToken: String,
@@ -38,6 +40,16 @@ data class Command(
     val action: String,
     val label: String,
     val description: String,
+)
+
+data class CalledCommand(
+    val timestamp: LocalDateTime,
+    val botUsername: String,
+    val chatId: Long,
+    val commandName: String,
+    val messageId: Long,
+    val result: Boolean,
+    val outcome: String,
 )
 
 data class Menu(

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/CalledCommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/CalledCommandProvider.kt
@@ -1,0 +1,16 @@
+package io.github.pm665.telegramboot.ports
+
+import io.github.pm665.telegramboot.domain.telegram.CalledCommand
+
+interface CalledCommandProvider {
+    fun getCalledCommands(): Collection<CalledCommand>
+
+    fun getForBot(botUsername: String): Collection<CalledCommand>
+
+    fun getForChat(
+        botUsername: String,
+        chatId: Long,
+    ): Collection<CalledCommand>
+
+    fun addCalledCommand(calledCommand: CalledCommand)
+}


### PR DESCRIPTION
## Summary
- add a `CalledCommand` domain model to capture executed command metadata
- expose a `CalledCommandProvider` port for retrieving stored command executions
- implement an `InMemoryCalledCommandProvider` adapter that keeps command call history in memory
- auto-configure the in-memory called command provider so it is available by default

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db29c9cbb883289d1d66a2054c7e10