### PR TITLE
Add parent lookup to menu provider

### DIFF
--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMenuProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMenuProvider.kt
@@ -14,6 +14,9 @@ class InMemoryMenuProvider : MenuProvider {
     override fun getForBot(botUsername: String): Collection<Menu> =
         menus.values.filter { it.botUsername == botUsername }
 
+    override fun getByParent(parent: String?, botUsername: String): Collection<Menu> =
+        menus.values.filter { it.botUsername == botUsername && it.parent == parent }
+
     override fun addMenu(menu: Menu) {
         val key = MenuKey(menu.command, menu.botUsername)
         menus[key] = menu

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MenuProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MenuProvider.kt
@@ -7,6 +7,8 @@ interface MenuProvider {
 
     fun getForBot(botUsername: String): Collection<Menu>
 
+    fun getByParent(parent: String?, botUsername: String): Collection<Menu>
+
     fun addMenu(menu: Menu)
 
     fun removeMenu(command: String, botUsername: String)


### PR DESCRIPTION
## Summary
- add a MenuProvider contract for fetching menus by parent command
- implement the parent-filtering lookup in the in-memory menu provider

## Testing
- ./gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db2db19428832881222d5f8e69e256