### PR TITLE
test: add auto-configuration tests

### DIFF
--- a/docs/autoconfiguration-testing.md
+++ b/docs/autoconfiguration-testing.md
@@ -1,0 +1,38 @@
+# Testing Spring Boot Auto-Configuration
+
+Effective auto-configuration tests combine unit, slice, and integration styles to cover the bean registration flow from multiple angles.
+
+## 1. Validate Conditions in Focused Tests
+Use `ApplicationContextRunner` (Gradle dependency `spring-boot-test`) to instantiate the auto-configuration with minimal context. Assert that conditional beans load when expected and remain absent otherwise. Prefer targeted property overrides per scenario to keep the test small.
+
+```kotlin
+private val contextRunner = ApplicationContextRunner()
+    .withConfiguration(AutoConfigurations.of(MyAutoConfiguration::class.java))
+
+@Test
+fun `creates client when token present`() {
+    contextRunner
+        .withPropertyValues("telegram.bot.token=secret")
+        .run { assertThat(it).hasSingleBean(TelegramClient::class.java) }
+}
+```
+
+## 2. Cover Negative Paths Explicitly
+Auto-configuration failures often stem from unmet conditions. Add dedicated tests for missing properties, incompatible classpath combinations, or customizers that disable beans. Ensure the `ConditionEvaluationReport` contains the expected outcomes when the bean is absent.
+
+## 3. Exercise Customization Hooks
+If the auto-configuration exposes customizers (e.g., `TelegramClientCustomizer` beans), wire sample beans into the `ApplicationContextRunner` and assert that they are applied in bean post-processing.
+
+## 4. Integrate with Spring Boot Test Slices
+When auto-configuration integrates with web, data, or messaging layers, combine it with relevant test slices (`@WebMvcTest`, `@DataJpaTest`) to ensure compatibility with Boot's managed infrastructure.
+
+## 5. Provide End-to-End Assurance
+Keep at least one full `@SpringBootTest` that uses the starter the way downstream users would, ideally in a sample application module. Validate critical beans and interactions, and consider running lightweight smoke tests (e.g., hitting an exposed HTTP endpoint) to catch wiring regressions.
+
+## 6. Use AssertJ and AutoConfigure Assertions
+Rely on Spring Boot's AssertJ extensions (`ConditionOutcomeMatcher`) or custom assert helpers to express bean presence, property binding, and condition matches clearly. Prefer expressive assertions over manual context lookups.
+
+## 7. Guard Against Regression with ContextCaching
+Leverage JUnit 5's `@DirtiesContext` sparingly; design tests to reuse cached contexts for speed. Group related scenarios in nested test classes to minimize context builds while keeping readability.
+
+Following this layered strategy ensures that the module's auto-configuration remains reliable as Spring Boot evolves and consumers integrate it into diverse applications.

--- a/telegram-boot-autoconfigure/build.gradle.kts
+++ b/telegram-boot-autoconfigure/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     testImplementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 mavenPublishing {

--- a/telegram-boot-autoconfigure/src/test/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfigurationTests.kt
+++ b/telegram-boot-autoconfigure/src/test/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfigurationTests.kt
@@ -1,0 +1,100 @@
+package io.github.pm665.telegramboot.bot.autoconfigure
+
+import io.github.pm665.telegramboot.domain.configuration.TelegramBootProperties
+import io.github.pm665.telegramboot.domain.telegram.Bot
+import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
+import io.github.pm665.telegramboot.ports.BotChatProvider
+import io.github.pm665.telegramboot.ports.BotProvider
+import io.github.pm665.telegramboot.ports.BotUserProvider
+import io.github.pm665.telegramboot.ports.CalledCommandProvider
+import io.github.pm665.telegramboot.ports.CommandProvider
+import io.github.pm665.telegramboot.ports.MenuProvider
+import io.github.pm665.telegramboot.ports.MessageProvider
+import io.github.pm665.telegramboot.ports.UserRoleProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.util.function.Supplier
+
+class TelegramBootServiceAutoConfigurationTests {
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TelegramBootServiceAutoConfiguration::class.java))
+
+    @Test
+    fun `registers default in-memory providers`() {
+        contextRunner.run { context ->
+            assertThat(context.getBeansOfType(BotProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(BotUserProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(BotChatProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(CommandProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(CalledCommandProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(MenuProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(UserRoleProvider::class.java)).hasSize(1)
+            assertThat(context.getBeansOfType(MessageProvider::class.java)).hasSize(1)
+        }
+    }
+
+    @Test
+    fun `binds telegram boot properties`() {
+        contextRunner
+            .withPropertyValues(
+                "telegram-boot.enabled=true",
+                "telegram-boot.name=myBot",
+            )
+            .run { context ->
+                val properties = context.getBean(TelegramBootProperties::class.java)
+                assertThat(properties.name).isEqualTo("myBot")
+                assertThat(properties.enabled).isTrue()
+            }
+    }
+
+    @Nested
+    inner class TelegramBootServiceCreation {
+        @Test
+        fun `creates telegram boot service when enabled`() {
+            contextRunner
+                .withPropertyValues("telegram-boot.enabled=true")
+                .run { context ->
+                    assertThat(context.getBeansOfType(TelegramBootService::class.java)).hasSize(1)
+                }
+        }
+
+        @Test
+        fun `does not create telegram boot service when disabled`() {
+            contextRunner
+                .withPropertyValues("telegram-boot.enabled=false")
+                .run { context ->
+                    assertThat(context.getBeansOfType(TelegramBootService::class.java)).isEmpty()
+                }
+        }
+
+        @Test
+        fun `does not create telegram boot service when property missing`() {
+            contextRunner.run { context ->
+                assertThat(context.getBeansOfType(TelegramBootService::class.java)).isEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun `backs off when user provides custom bot provider`() {
+        contextRunner
+            .withBean(BotProvider::class.java, Supplier { TestBotProvider() })
+            .run { context ->
+                val beans = context.getBeansOfType(BotProvider::class.java)
+                assertThat(beans).hasSize(1)
+                assertThat(beans.values.single()).isInstanceOf(TestBotProvider::class.java)
+            }
+    }
+
+    private class TestBotProvider : BotProvider {
+        override fun getBots(): Collection<Bot> = emptyList()
+
+        override fun addBot(bot: Bot) = Unit
+
+        override fun removeBot(botUsername: String) = Unit
+    }
+}

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryBotChatProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryBotChatProvider.kt
@@ -9,8 +9,7 @@ class InMemoryBotChatProvider : BotChatProvider {
 
     override fun getBotChats(): Collection<BotChat> = botChats.values.toList()
 
-    override fun getForBot(botUsername: String): Collection<BotChat> =
-        botChats.values.filter { it.botUsername == botUsername }
+    override fun getForBot(botUsername: String): Collection<BotChat> = botChats.values.filter { it.botUsername == botUsername }
 
     override fun addBotChat(botChat: BotChat) {
         botChats[botChat.botChatId] = botChat

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryCommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryCommandProvider.kt
@@ -11,18 +11,22 @@ class InMemoryCommandProvider : CommandProvider {
 
     override fun getCommands(): Collection<Command> = commands.values.toList()
 
-    override fun getForBot(botUsername: String): Collection<Command> =
-        commands.values.filter { it.botUsername == botUsername }
+    override fun getForBot(botUsername: String): Collection<Command> = commands.values.filter { it.botUsername == botUsername }
 
-    override fun getByCommand(commandName: String, botUsername: String): Command? =
-        commands[CommandKey(commandName, botUsername)]
+    override fun getByCommand(
+        commandName: String,
+        botUsername: String,
+    ): Command? = commands[CommandKey(commandName, botUsername)]
 
     override fun addCommand(command: Command) {
         val key = CommandKey(command.command, command.botUsername)
         commands[key] = command
     }
 
-    override fun removeCommand(commandName: String, botUsername: String) {
+    override fun removeCommand(
+        commandName: String,
+        botUsername: String,
+    ) {
         val key = CommandKey(commandName, botUsername)
         commands.remove(key)
     }

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMenuProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryMenuProvider.kt
@@ -11,18 +11,22 @@ class InMemoryMenuProvider : MenuProvider {
 
     override fun getMenus(): Collection<Menu> = menus.values.toList()
 
-    override fun getForBot(botUsername: String): Collection<Menu> =
-        menus.values.filter { it.botUsername == botUsername }
+    override fun getForBot(botUsername: String): Collection<Menu> = menus.values.filter { it.botUsername == botUsername }
 
-    override fun getByParent(parent: String?, botUsername: String): Collection<Menu> =
-        menus.values.filter { it.botUsername == botUsername && it.parent == parent }
+    override fun getByParent(
+        parent: String?,
+        botUsername: String,
+    ): Collection<Menu> = menus.values.filter { it.botUsername == botUsername && it.parent == parent }
 
     override fun addMenu(menu: Menu) {
         val key = MenuKey(menu.command, menu.botUsername)
         menus[key] = menu
     }
 
-    override fun removeMenu(command: String, botUsername: String) {
+    override fun removeMenu(
+        command: String,
+        botUsername: String,
+    ) {
         val key = MenuKey(command, botUsername)
         menus.remove(key)
     }

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryUserRoleProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/adapters/InMemoryUserRoleProvider.kt
@@ -12,15 +12,18 @@ class InMemoryUserRoleProvider : UserRoleProvider {
 
     override fun getUserRoles(): Collection<UserRole> = userRoles.values.toList()
 
-    override fun getForBot(botUsername: String): Collection<UserRole> =
-        userRoles.values.filter { it.botUsername == botUsername }
+    override fun getForBot(botUsername: String): Collection<UserRole> = userRoles.values.filter { it.botUsername == botUsername }
 
     override fun addUserRole(userRole: UserRole) {
         val key = UserRoleKey(userRole.botUsername, userRole.botUserId, userRole.role)
         userRoles[key] = userRole
     }
 
-    override fun removeUserRole(botUsername: String?, botUserId: Long, role: Role) {
+    override fun removeUserRole(
+        botUsername: String?,
+        botUserId: Long,
+        role: Role,
+    ) {
         val key = UserRoleKey(botUsername, botUserId, role)
         userRoles.remove(key)
     }

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/CommandProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/CommandProvider.kt
@@ -7,9 +7,15 @@ interface CommandProvider {
 
     fun getForBot(botUsername: String): Collection<Command>
 
-    fun getByCommand(commandName: String, botUsername: String): Command?
+    fun getByCommand(
+        commandName: String,
+        botUsername: String,
+    ): Command?
 
     fun addCommand(command: Command)
 
-    fun removeCommand(commandName: String, botUsername: String)
+    fun removeCommand(
+        commandName: String,
+        botUsername: String,
+    )
 }

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MenuProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/MenuProvider.kt
@@ -7,9 +7,15 @@ interface MenuProvider {
 
     fun getForBot(botUsername: String): Collection<Menu>
 
-    fun getByParent(parent: String?, botUsername: String): Collection<Menu>
+    fun getByParent(
+        parent: String?,
+        botUsername: String,
+    ): Collection<Menu>
 
     fun addMenu(menu: Menu)
 
-    fun removeMenu(command: String, botUsername: String)
+    fun removeMenu(
+        command: String,
+        botUsername: String,
+    )
 }

--- a/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/UserRoleProvider.kt
+++ b/telegram-boot-core/src/main/kotlin/io/github/pm665/telegramboot/ports/UserRoleProvider.kt
@@ -10,5 +10,9 @@ interface UserRoleProvider {
 
     fun addUserRole(userRole: UserRole)
 
-    fun removeUserRole(botUsername: String?, botUserId: Long, role: Role)
+    fun removeUserRole(
+        botUsername: String?,
+        botUserId: Long,
+        role: Role,
+    )
 }


### PR DESCRIPTION
## Summary
- add ApplicationContextRunner-based coverage for TelegramBootServiceAutoConfiguration, including conditional beans and backing off when user beans exist
- configure the autoconfigure module with the JUnit Platform launcher required to execute the new tests
- apply Spotless formatting updates generated during the build across in-memory providers and port interfaces

## Testing
- ./gradlew :telegram-boot-autoconfigure:test

------
https://chatgpt.com/codex/tasks/task_e_68dc34aa59088328bf62c5a1396feeab