### PR TITLE
Add comprehensive test coverage across modules

### DIFF
--- a/telegram-boot-autoconfigure/src/test/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfigurationTests.kt
+++ b/telegram-boot-autoconfigure/src/test/kotlin/io/github/pm665/telegramboot/bot/autoconfigure/TelegramBootServiceAutoConfigurationTests.kt
@@ -2,7 +2,15 @@ package io.github.pm665.telegramboot.bot.autoconfigure
 
 import io.github.pm665.telegramboot.domain.configuration.TelegramBootProperties
 import io.github.pm665.telegramboot.domain.telegram.Bot
+import io.github.pm665.telegramboot.domain.telegram.BotChat
+import io.github.pm665.telegramboot.domain.telegram.BotUser
+import io.github.pm665.telegramboot.domain.telegram.CalledCommand
+import io.github.pm665.telegramboot.domain.telegram.Command
+import io.github.pm665.telegramboot.domain.telegram.Menu
+import io.github.pm665.telegramboot.domain.telegram.Message
+import io.github.pm665.telegramboot.domain.telegram.Role
 import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
+import io.github.pm665.telegramboot.domain.telegram.UserRole
 import io.github.pm665.telegramboot.ports.BotChatProvider
 import io.github.pm665.telegramboot.ports.BotProvider
 import io.github.pm665.telegramboot.ports.BotUserProvider
@@ -80,13 +88,44 @@ class TelegramBootServiceAutoConfigurationTests {
     }
 
     @Test
-    fun `backs off when user provides custom bot provider`() {
+    fun `backs off when user provides custom in-memory beans`() {
+        assertBacksOff(BotProvider::class.java, CustomBotProviderConfiguration::class.java, TestBotProvider::class.java)
+        assertBacksOff(BotUserProvider::class.java, CustomBotUserProviderConfiguration::class.java, TestBotUserProvider::class.java)
+        assertBacksOff(BotChatProvider::class.java, CustomBotChatProviderConfiguration::class.java, TestBotChatProvider::class.java)
+        assertBacksOff(CommandProvider::class.java, CustomCommandProviderConfiguration::class.java, TestCommandProvider::class.java)
+        assertBacksOff(
+            CalledCommandProvider::class.java,
+            CustomCalledCommandProviderConfiguration::class.java,
+            TestCalledCommandProvider::class.java,
+        )
+        assertBacksOff(MenuProvider::class.java, CustomMenuProviderConfiguration::class.java, TestMenuProvider::class.java)
+        assertBacksOff(UserRoleProvider::class.java, CustomUserRoleProviderConfiguration::class.java, TestUserRoleProvider::class.java)
+        assertBacksOff(MessageProvider::class.java, CustomMessageProviderConfiguration::class.java, TestMessageProvider::class.java)
+    }
+
+    @Test
+    fun `backs off when user provides telegram boot service`() {
+        val customService = TelegramBootService(TelegramBootProperties().apply { name = "custom" })
+
         contextRunner
-            .withBean(BotProvider::class.java, Supplier { TestBotProvider() })
+            .withPropertyValues("telegram-boot.enabled=true")
+            .withBean(TelegramBootService::class.java, Supplier { customService })
             .run { context ->
-                val beans = context.getBeansOfType(BotProvider::class.java)
+                assertThat(context.getBean(TelegramBootService::class.java)).isSameAs(customService)
+            }
+    }
+
+    private fun <T : Any> assertBacksOff(
+        beanType: Class<T>,
+        configurationClass: Class<*>,
+        expectedType: Class<out T>,
+    ) {
+        contextRunner
+            .withUserConfiguration(configurationClass)
+            .run { context ->
+                val beans = context.getBeansOfType(beanType)
                 assertThat(beans).hasSize(1)
-                assertThat(beans.values.single()).isInstanceOf(TestBotProvider::class.java)
+                assertThat(beans.values.single()).isInstanceOf(expectedType)
             }
     }
 
@@ -96,5 +135,147 @@ class TelegramBootServiceAutoConfigurationTests {
         override fun addBot(bot: Bot) = Unit
 
         override fun removeBot(botUsername: String) = Unit
+    }
+
+    private class TestBotUserProvider : BotUserProvider {
+        override fun getBotUsers(): Collection<BotUser> = emptyList()
+
+        override fun addBotUser(botUser: BotUser) = Unit
+
+        override fun removeBotUser(botUserId: Long) = Unit
+    }
+
+    private class TestBotChatProvider : BotChatProvider {
+        override fun getBotChats(): Collection<BotChat> = emptyList()
+
+        override fun getForBot(botUsername: String): Collection<BotChat> = emptyList()
+
+        override fun addBotChat(botChat: BotChat) = Unit
+
+        override fun removeBotChat(botChatId: Long) = Unit
+    }
+
+    private class TestCommandProvider : CommandProvider {
+        override fun getCommands(): Collection<Command> = emptyList()
+
+        override fun getForBot(botUsername: String): Collection<Command> = emptyList()
+
+        override fun getByCommand(
+            commandName: String,
+            botUsername: String,
+        ): Command? = null
+
+        override fun addCommand(command: Command) = Unit
+
+        override fun removeCommand(
+            commandName: String,
+            botUsername: String,
+        ) = Unit
+    }
+
+    private class TestCalledCommandProvider : CalledCommandProvider {
+        override fun getCalledCommands(): Collection<CalledCommand> = emptyList()
+
+        override fun getForBot(botUsername: String): Collection<CalledCommand> = emptyList()
+
+        override fun getForChat(
+            botUsername: String,
+            chatId: Long,
+        ): Collection<CalledCommand> = emptyList()
+
+        override fun addCalledCommand(calledCommand: CalledCommand) = Unit
+    }
+
+    private class TestMenuProvider : MenuProvider {
+        override fun getMenus(): Collection<Menu> = emptyList()
+
+        override fun getForBot(botUsername: String): Collection<Menu> = emptyList()
+
+        override fun getByParent(
+            parent: String?,
+            botUsername: String,
+        ): Collection<Menu> = emptyList()
+
+        override fun addMenu(menu: Menu) = Unit
+
+        override fun removeMenu(
+            command: String,
+            botUsername: String,
+        ) = Unit
+    }
+
+    private class TestUserRoleProvider : UserRoleProvider {
+        override fun getUserRoles(): Collection<UserRole> = emptyList()
+
+        override fun getForBot(botUsername: String): Collection<UserRole> = emptyList()
+
+        override fun addUserRole(userRole: UserRole) = Unit
+
+        override fun removeUserRole(
+            botUsername: String?,
+            botUserId: Long,
+            role: Role,
+        ) = Unit
+    }
+
+    private class TestMessageProvider : MessageProvider {
+        override fun getMessages(): Collection<Message> = emptyList()
+
+        override fun getByBotAndChat(
+            botUsername: String,
+            chatId: Long,
+        ): Collection<Message> = emptyList()
+
+        override fun addMessage(message: Message) = Unit
+
+        override fun removeMessage(messageId: String) = Unit
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomBotProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun botProvider(): BotProvider = TestBotProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomBotUserProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun botUserProvider(): BotUserProvider = TestBotUserProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomBotChatProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun botChatProvider(): BotChatProvider = TestBotChatProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomCommandProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun commandProvider(): CommandProvider = TestCommandProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomCalledCommandProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun calledCommandProvider(): CalledCommandProvider = TestCalledCommandProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomMenuProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun menuProvider(): MenuProvider = TestMenuProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomUserRoleProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun userRoleProvider(): UserRoleProvider = TestUserRoleProvider()
+    }
+
+    @org.springframework.context.annotation.Configuration
+    private class CustomMessageProviderConfiguration {
+        @org.springframework.context.annotation.Bean
+        fun messageProvider(): MessageProvider = TestMessageProvider()
     }
 }

--- a/telegram-boot-core/build.gradle.kts
+++ b/telegram-boot-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 mavenPublishing {

--- a/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/adapters/InMemoryProvidersTest.kt
+++ b/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/adapters/InMemoryProvidersTest.kt
@@ -1,0 +1,163 @@
+package io.github.pm665.telegramboot.adapters
+
+import io.github.pm665.telegramboot.domain.telegram.Bot
+import io.github.pm665.telegramboot.domain.telegram.BotChat
+import io.github.pm665.telegramboot.domain.telegram.BotUser
+import io.github.pm665.telegramboot.domain.telegram.CalledCommand
+import io.github.pm665.telegramboot.domain.telegram.Command
+import io.github.pm665.telegramboot.domain.telegram.CommandType
+import io.github.pm665.telegramboot.domain.telegram.Menu
+import io.github.pm665.telegramboot.domain.telegram.Message
+import io.github.pm665.telegramboot.domain.telegram.Role
+import io.github.pm665.telegramboot.domain.telegram.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class InMemoryProvidersTest {
+    @Test
+    fun `bot provider replaces bot with same username`() {
+        val provider = InMemoryBotProvider()
+        val initial = Bot(botUsername = "espresso_bot", botToken = "old", enabled = true)
+        val replacement = initial.copy(botToken = "new", enabled = false)
+
+        provider.addBot(initial)
+        provider.addBot(replacement)
+
+        val stored = provider.getBots().single { it.botUsername == "espresso_bot" }
+        assertThat(stored.botToken).isEqualTo("new")
+        assertThat(stored.enabled).isFalse()
+
+        provider.removeBot("espresso_bot")
+        assertThat(provider.getBots()).isEmpty()
+    }
+
+    @Test
+    fun `bot user provider stores and removes users`() {
+        val provider = InMemoryBotUserProvider()
+        val user = BotUser(botUserId = 1L, username = "barista", active = true)
+
+        provider.addBotUser(user)
+        assertThat(provider.getBotUsers()).containsExactly(user)
+
+        provider.removeBotUser(1L)
+        assertThat(provider.getBotUsers()).isEmpty()
+    }
+
+    @Test
+    fun `bot chat provider filters by bot and removes chats`() {
+        val provider = InMemoryBotChatProvider()
+        val chat = BotChat(botUsername = "espresso_bot", botUserId = 1L, botChatId = 42L)
+        val other = BotChat(botUsername = "latte_bot", botUserId = 2L, botChatId = 100L)
+
+        provider.addBotChat(chat)
+        provider.addBotChat(other)
+
+        assertThat(provider.getForBot("espresso_bot")).containsExactly(chat)
+
+        provider.removeBotChat(42L)
+        assertThat(provider.getBotChats()).containsExactly(other)
+    }
+
+    @Test
+    fun `command provider retrieves and replaces commands`() {
+        val provider = InMemoryCommandProvider()
+        val command =
+            Command(
+                command = "/start",
+                botUsername = "espresso_bot",
+                enabled = true,
+                type = CommandType.COMMAND,
+                action = "start",
+                label = "Start",
+                description = "Start",
+            )
+        provider.addCommand(command)
+
+        val replacement = command.copy(description = "Start again")
+        provider.addCommand(replacement)
+
+        assertThat(provider.getByCommand("/start", "espresso_bot")).isEqualTo(replacement)
+        assertThat(provider.getForBot("espresso_bot")).containsExactly(replacement)
+
+        provider.removeCommand("/start", "espresso_bot")
+        assertThat(provider.getCommands()).isEmpty()
+    }
+
+    @Test
+    fun `called command provider filters by bot and chat`() {
+        val provider = InMemoryCalledCommandProvider()
+        val timestamp = LocalDateTime.now()
+        val target =
+            CalledCommand(
+                timestamp = timestamp,
+                botUsername = "espresso_bot",
+                chatId = 99L,
+                commandName = "/start",
+                messageId = 1L,
+                result = true,
+                outcome = "ok",
+            )
+        val other =
+            target.copy(
+                botUsername = "latte_bot",
+                chatId = 100L,
+                messageId = 2L,
+            )
+
+        provider.addCalledCommand(target)
+        provider.addCalledCommand(other)
+
+        assertThat(provider.getForBot("espresso_bot")).containsExactly(target)
+        assertThat(provider.getForChat("espresso_bot", 99L)).containsExactly(target)
+    }
+
+    @Test
+    fun `menu provider returns menus by bot and parent`() {
+        val provider = InMemoryMenuProvider()
+        val root = Menu(command = "/root", botUsername = "espresso_bot", enabled = true, parent = null, section = 0, row = 0, order = 0)
+        val child = root.copy(command = "/child", parent = "/root", order = 1)
+        val otherBot = root.copy(botUsername = "latte_bot", command = "/latte")
+
+        provider.addMenu(root)
+        provider.addMenu(child)
+        provider.addMenu(otherBot)
+
+        assertThat(provider.getForBot("espresso_bot")).containsExactlyInAnyOrder(root, child)
+        assertThat(provider.getByParent("/root", "espresso_bot")).containsExactly(child)
+
+        provider.removeMenu("/root", "espresso_bot")
+        assertThat(provider.getForBot("espresso_bot")).containsExactly(child)
+    }
+
+    @Test
+    fun `message provider filters by bot and chat`() {
+        val provider = InMemoryMessageProvider()
+        val message = Message(id = "1", botUsername = "espresso_bot", chatId = 42L, className = "Update", update = Any())
+        val other = Message(id = "2", botUsername = "espresso_bot", chatId = 100L, className = "Update", update = Any())
+
+        provider.addMessage(message)
+        provider.addMessage(other)
+
+        assertThat(provider.getByBotAndChat("espresso_bot", 42L)).containsExactly(message)
+
+        provider.removeMessage("1")
+        assertThat(provider.getMessages()).containsExactly(other)
+    }
+
+    @Test
+    fun `user role provider treats bot username as part of key`() {
+        val provider = InMemoryUserRoleProvider()
+        val globalAdmin = UserRole(botUsername = null, botUserId = 1L, role = Role.SUPER_ADMIN)
+        val scopedAdmin = UserRole(botUsername = "espresso_bot", botUserId = 1L, role = Role.BOT_ADMIN)
+
+        provider.addUserRole(globalAdmin)
+        provider.addUserRole(scopedAdmin)
+
+        assertThat(provider.getUserRoles()).containsExactlyInAnyOrder(globalAdmin, scopedAdmin)
+        assertThat(provider.getForBot("espresso_bot")).containsExactly(scopedAdmin)
+
+        provider.removeUserRole(null, 1L, Role.SUPER_ADMIN)
+        assertThat(provider.getUserRoles()).containsExactly(scopedAdmin)
+    }
+}

--- a/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/configuration/TelegramBootPropertiesTest.kt
+++ b/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/configuration/TelegramBootPropertiesTest.kt
@@ -1,0 +1,35 @@
+package io.github.pm665.telegramboot.domain.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Bindable
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+
+class TelegramBootPropertiesTest {
+    @Test
+    fun `defaults are applied`() {
+        val properties = TelegramBootProperties()
+
+        assertThat(properties.name).isEqualTo("telegramBoot")
+        assertThat(properties.enabled).isTrue()
+    }
+
+    @Test
+    fun `binds custom configuration`() {
+        val source =
+            MapConfigurationPropertySource(
+                mapOf(
+                    "telegram-boot.name" to "custom-bot",
+                    "telegram-boot.enabled" to "false",
+                ),
+            )
+
+        val binder = Binder(source)
+
+        val bound = binder.bind("telegram-boot", Bindable.of(TelegramBootProperties::class.java)).get()
+
+        assertThat(bound.name).isEqualTo("custom-bot")
+        assertThat(bound.enabled).isFalse()
+    }
+}

--- a/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModelsTest.kt
+++ b/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/telegram/BotModelsTest.kt
@@ -1,0 +1,31 @@
+package io.github.pm665.telegramboot.domain.telegram
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BotModelsTest {
+    @Test
+    fun `bot user defaults to inactive`() {
+        val botUser = BotUser(botUserId = 1L, username = "coffee")
+
+        assertThat(botUser.active).isFalse()
+    }
+
+    @Test
+    fun `menu equality is based on structural data`() {
+        val menuOne =
+            Menu(
+                command = "/brew",
+                botUsername = "espresso_bot",
+                enabled = true,
+                parent = null,
+                section = 0,
+                row = 0,
+                order = 0,
+            )
+        val menuTwo = menuOne.copy()
+
+        assertThat(menuOne).isEqualTo(menuTwo)
+        assertThat(menuOne.hashCode()).isEqualTo(menuTwo.hashCode())
+    }
+}

--- a/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/telegram/TelegramBootServiceTest.kt
+++ b/telegram-boot-core/src/test/kotlin/io/github/pm665/telegramboot/domain/telegram/TelegramBootServiceTest.kt
@@ -1,0 +1,30 @@
+package io.github.pm665.telegramboot.domain.telegram
+
+import io.github.pm665.telegramboot.domain.configuration.TelegramBootProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+
+@ExtendWith(OutputCaptureExtension::class)
+class TelegramBootServiceTest {
+    @Test
+    fun `returns configured bot name`() {
+        val properties = TelegramBootProperties().apply { name = "test-bot" }
+
+        val service = TelegramBootService(properties)
+
+        assertThat(service.botName()).isEqualTo("test-bot")
+    }
+
+    @Test
+    fun `logs configured bot name on initialization`(capturedOutput: CapturedOutput) {
+        val properties = TelegramBootProperties().apply { name = "logging-bot" }
+
+        TelegramBootService(properties)
+
+        assertThat(capturedOutput.out)
+            .contains("Telegram boot 'logging-bot' is ready to receive updates")
+    }
+}

--- a/telegram-boot-sample-app/build.gradle.kts
+++ b/telegram-boot-sample-app/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
     implementation(kotlin("reflect"))
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/telegram-boot-sample-app/src/test/kotlin/io/github/pm665/telegramboot/app/TelegramBootApplicationTests.kt
+++ b/telegram-boot-sample-app/src/test/kotlin/io/github/pm665/telegramboot/app/TelegramBootApplicationTests.kt
@@ -1,0 +1,72 @@
+package io.github.pm665.telegramboot.app
+
+import io.github.pm665.telegramboot.domain.telegram.Bot
+import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
+import io.github.pm665.telegramboot.ports.BotProvider
+import io.github.pm665.telegramboot.ports.CommandProvider
+import io.github.pm665.telegramboot.ports.MenuProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+
+@SpringBootTest(
+    classes = [TelegramBootApplication::class],
+    properties = [
+        "telegram-boot.enabled=true",
+        "telegram-boot.name=test-bot",
+    ],
+)
+@ExtendWith(OutputCaptureExtension::class)
+class TelegramBootApplicationTests {
+    @Autowired
+    private lateinit var sampleMenuRunner: CommandLineRunner
+
+    @Autowired
+    private lateinit var telegramLogger: CommandLineRunner
+
+    @Autowired
+    private lateinit var botProvider: BotProvider
+
+    @Autowired
+    private lateinit var commandProvider: CommandProvider
+
+    @Autowired
+    private lateinit var menuProvider: MenuProvider
+
+    @Autowired
+    private lateinit var telegramBootService: TelegramBootService
+
+    @Test
+    fun `sample menu runner populates providers`() {
+        sampleMenuRunner.run()
+
+        val botUsernames = botProvider.getBots().map(Bot::botUsername)
+        assertThat(botUsernames).containsExactlyInAnyOrder("espresso_bot", "latte_bot")
+
+        val espressoCommands = commandProvider.getForBot("espresso_bot")
+        assertThat(espressoCommands).hasSizeGreaterThanOrEqualTo(1)
+        assertThat(espressoCommands.map { it.command })
+            .contains("/settings_notifications", "/settings_profile")
+
+        val espressoMenus = menuProvider.getForBot("espresso_bot")
+        assertThat(espressoMenus.map { it.command })
+            .contains("/start", "/status", "/settings", "/settings_profile")
+
+        val childMenus = menuProvider.getByParent("/settings", "espresso_bot")
+        assertThat(childMenus).allMatch { it.parent == "/settings" }
+    }
+
+    @Test
+    fun `telegram logger writes configured bot name`(capturedOutput: CapturedOutput) {
+        telegramLogger.run()
+
+        assertThat(capturedOutput.out)
+            .contains("Telegram boot 'test-bot' is ready to receive updates")
+        assertThat(telegramBootService.botName()).isEqualTo("test-bot")
+    }
+}

--- a/telegram-boot-spring-boot-starter/build.gradle.kts
+++ b/telegram-boot-spring-boot-starter/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     api(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
     api(project(":telegram-boot-core"))
     implementation(project(":telegram-boot-autoconfigure"))
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 mavenPublishing {

--- a/telegram-boot-spring-boot-starter/src/test/kotlin/io/github/pm665/telegramboot/starter/TelegramBootStarterTests.kt
+++ b/telegram-boot-spring-boot-starter/src/test/kotlin/io/github/pm665/telegramboot/starter/TelegramBootStarterTests.kt
@@ -1,0 +1,45 @@
+package io.github.pm665.telegramboot.starter
+
+import io.github.pm665.telegramboot.domain.telegram.TelegramBootService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.io.ClassPathResource
+
+class TelegramBootStarterTests {
+    @Test
+    fun `auto configuration imports file exposes telegram boot configuration`() {
+        val resource = ClassPathResource("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
+
+        assertThat(resource.exists()).isTrue()
+
+        val entries =
+            resource.inputStream.bufferedReader().useLines { lines ->
+                lines.filter { it.isNotBlank() && !it.trim().startsWith("#") }.toList()
+            }
+
+        assertThat(entries)
+            .contains("io.github.pm665.telegramboot.bot.autoconfigure.TelegramBootServiceAutoConfiguration")
+    }
+
+    @Test
+    fun `starter makes telegram boot service auto configuration available`() {
+        val resource = ClassPathResource("META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports")
+        val autoConfigurationClasses =
+            resource.inputStream.bufferedReader().useLines { lines ->
+                lines.filter { it.isNotBlank() && !it.trim().startsWith("#") }
+                    .map { Class.forName(it) }
+                    .toList()
+            }
+
+        val runner =
+            ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(*autoConfigurationClasses.toTypedArray()))
+                .withPropertyValues("telegram-boot.enabled=true")
+
+        runner.run { context ->
+            assertThat(context).hasSingleBean(TelegramBootService::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add focused unit tests for core services, configuration, and in-memory providers
- expand auto-configuration coverage for conditional bean back-offs and starter discovery
- add sample application smoke tests and ensure junit platform launcher is on test classpaths

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dc4dac632083288798c1fb15c1fc6f